### PR TITLE
Add snapcraft yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,34 @@
+name: monolith
+base: core18 
+version: git
+summary: Monolith - Save HTML pages with ease 
+description: |
+  A data hoarder's dream come true: bundle any web page into a single
+  HTML file. You can finally replace that gazillion of open tabs with
+  a gazillion of .html files stored somewhere on your precious little
+  drive.
+  Unlike conventional "Save page as…", monolith not only saves the
+  target document, it embeds CSS, image, and JavaScript assets all
+  at once, producing a single HTML5 document that is a joy to store
+  and share.
+  If compared to saving websites with wget -mpk, monolith embeds
+  all assets as data URLs and therefore displays the saved page
+  exactly the same, being completely separated from the Internet.
+
+confinement: strict
+
+parts:
+  monolith:
+    plugin: rust
+    source: .
+    build-packages:
+      - libssl-dev
+      - pkg-config
+
+apps:
+  monolith:
+    command: monolith
+    plugs:
+      - home
+      - network
+      - removable-media


### PR DESCRIPTION
Hello. I'm Alan, and I work for Canonical on [Snapcraft](https://snapcraft.io/), an app store for Linux used by many high profile and indie developers.

This PR adds support for building a [snap](https://snapcraft.io/) of monolith. I've tested it on my Ubuntu laptop by cloning this branch in a folder and doing:-

```
snap install snapcraft
snap install multipass
cd monolith
snapcraft
```

This built a snap which can work on numerous Linux distributions. I tested it with:

```
snap install monolith_0+git.27f1411_amd64.snap --dangerous
```

(`--dangerous` is required because the snap is being 'side-loaded' without being checked/signed by the [snap store](https://snapcraft.io/store))

I registered the name `monolith` in the snap store and pushed these builds to the edge channel. Users can test this on systems which have [snap support](https://snapcraft.io/docs/installing-snapd) build with `snap install monolith --edge`.

If accepted, I'd be happy to transfer ownership of `monolith` snap to you, as the upstream. You could then use https://build.snapcraft.io/ to automatically build and publish snaps for amd64,i386,armhf,arm64,s390x and powerpc to the store, directly to users.

Happy to answer any further questions or improve my PR if needed.