### PR TITLE
Add CSP isolation, no CSS and no iframe options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ rust:
     - beta 
     - nightly
 
+before_script:
+    - rustup component add rustfmt
+
 script:
     - cargo build --verbose
     - cargo test --verbose
+    - cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monolith"
-version = "2.0.17"
+version = "2.0.18"
 authors = [
     "Sunshine <sunshine@uberspace.net>",
     "Mahdi Robatipoor <mahdi.robatipoor@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Travis CI Build Status](https://travis-ci.org/Y2Z/monolith.svg?branch=master)](https://travis-ci.org/Y2Z/monolith)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/j1v1d96sw952b1ch?svg=true)](https://ci.appveyor.com/project/vflyson/monolith)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/ae7soyjih8jg2bv7/branch/master?svg=true)](https://ci.appveyor.com/project/snshn/monolith/branch/master)
+
 
 # monolith
 
@@ -21,7 +22,10 @@ If compared to saving websites with `wget -mpk`, this tool embeds all assets as 
     $ monolith https://lyrics.github.io/db/p/portishead/dummy/roads/ > portishead-roads-lyrics.html
 
 ### Options
+ - `-c`: Ignore styles
+ - `-f`: Exclude iframes
  - `-i`: Remove images
+ - `-I`: Isolate document
  - `-j`: Exclude JavaScript
  - `-k`: Accept invalid X.509 (TLS) certificates
  - `-s`: Silent mode

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -114,6 +114,7 @@ install:
   - if defined MINGW_PATH set PATH=%PATH%;%MINGW_PATH%
   - rustc -vV
   - cargo -vV
+  - rustup component add rustfmt
 
 ## Build Script ##
 
@@ -125,4 +126,5 @@ build: false
 #directly or perform other testing commands. Rust will automatically be placed in the PATH
 # environment variable.
 test_script:
-- cargo test --verbose %cargoflags%
+  - cargo test --verbose %cargoflags%
+  - cargo fmt --all -- --check

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
-use reqwest::Client;
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
+use reqwest::Client;
 use std::time::Duration;
 use url::{ParseError, Url};
 use utils::data_to_dataurl;
@@ -46,10 +46,7 @@ pub fn retrieve_asset(
             .timeout(Duration::from_secs(10))
             .danger_accept_invalid_certs(opt_insecure)
             .build()?;
-        let mut response = client
-            .get(url)
-            .header(USER_AGENT, opt_user_agent)
-            .send()?;
+        let mut response = client.get(url).header(USER_AGENT, opt_user_agent).send()?;
         let final_url = response.url().as_str();
 
         if !opt_silent {
@@ -102,19 +99,13 @@ mod tests {
 
     #[test]
     fn test_resolve_url() -> Result<(), ParseError> {
-        let resolved_url = resolve_url(
-            "https://www.kernel.org",
-            "../category/signatures.html",
-        )?;
+        let resolved_url = resolve_url("https://www.kernel.org", "../category/signatures.html")?;
         assert_eq!(
             resolved_url.as_str(),
             "https://www.kernel.org/category/signatures.html"
         );
 
-        let resolved_url = resolve_url(
-            "https://www.kernel.org",
-            "category/signatures.html",
-        )?;
+        let resolved_url = resolve_url("https://www.kernel.org", "category/signatures.html")?;
         assert_eq!(
             resolved_url.as_str(),
             "https://www.kernel.org/category/signatures.html"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate clap;
 extern crate monolith;
 
 use clap::{App, Arg};
-use monolith::html::{html_to_dom, print_dom, walk_and_embed_assets};
+use monolith::html::{html_to_dom, stringify_document, walk_and_embed_assets};
 use monolith::http::{is_valid_url, retrieve_asset};
 
 static DEFAULT_USER_AGENT: &str =
@@ -21,43 +21,60 @@ fn main() {
                 .index(1)
                 .help("URL to download"),
         )
-        .args_from_usage("-i, --no-images 'Removes images'")
-        .args_from_usage("-j, --no-js 'Excludes JavaScript'")
+        .args_from_usage("-c, --no-css 'Ignore styles'")
+        .args_from_usage("-f, --no-frames 'Exclude iframes'")
+        .args_from_usage("-i, --no-images 'Remove images'")
+        .args_from_usage("-I, --isolate 'Cut off from the Internet'")
+        .args_from_usage("-j, --no-js 'Exclude JavaScript'")
         .args_from_usage("-k, --insecure 'Accept invalid X.509 (TLS) certificates'")
         .args_from_usage("-s, --silent 'Suppress verbosity'")
         .args_from_usage("-u, --user-agent=[Iceweasel] 'Custom User-Agent string'")
         .get_matches();
 
     // Process the command
-    let arg_target = command.value_of("url").unwrap();
-    let opt_no_images = command.is_present("no-images");
-    let opt_no_js = command.is_present("no-js");
-    let opt_insecure = command.is_present("insecure");
-    let opt_silent = command.is_present("silent");
-    let opt_user_agent = command.value_of("user-agent").unwrap_or(DEFAULT_USER_AGENT);
+    let arg_target: &str = command.value_of("url").unwrap();
+    let opt_no_css: bool = command.is_present("no-css");
+    let opt_no_frames: bool = command.is_present("no-frames");
+    let opt_no_images: bool = command.is_present("no-images");
+    let opt_no_js: bool = command.is_present("no-js");
+    let opt_insecure: bool = command.is_present("insecure");
+    let opt_isolate: bool = command.is_present("isolate");
+    let opt_silent: bool = command.is_present("silent");
+    let opt_user_agent: &str = command.value_of("user-agent").unwrap_or(DEFAULT_USER_AGENT);
 
     if is_valid_url(arg_target) {
         let data = retrieve_asset(
-                &arg_target,
-                false,
-                "",
-                opt_user_agent,
-                opt_silent,
-                opt_insecure,
-            ).unwrap();
+            &arg_target,
+            false,
+            "",
+            opt_user_agent,
+            opt_silent,
+            opt_insecure,
+        )
+        .unwrap();
         let dom = html_to_dom(&data);
 
         walk_and_embed_assets(
             &arg_target,
             &dom.document,
+            opt_no_css,
             opt_no_js,
             opt_no_images,
             opt_user_agent,
             opt_silent,
             opt_insecure,
+            opt_no_frames,
         );
 
-        print_dom(&dom.document);
-        println!(); // Ensure newline at end of output
+        let html: String = stringify_document(
+            &dom.document,
+            opt_no_css,
+            opt_no_frames,
+            opt_no_js,
+            opt_no_images,
+            opt_isolate,
+        );
+
+        println!("{}", html);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ extern crate base64;
 
 use self::base64::encode;
 
-static MAGIC: [[&[u8]; 2]; 19]  = [
+static MAGIC: [[&[u8]; 2]; 19] = [
     // Image
     [b"GIF87a", b"image/gif"],
     [b"GIF89a", b"image/gif"],
@@ -39,7 +39,7 @@ pub fn data_to_dataurl(mime: &str, data: &[u8]) -> String {
 fn detect_mimetype(data: &[u8]) -> String {
     let mut re = String::new();
 
-    for item in MAGIC.iter()  {
+    for item in MAGIC.iter() {
         if data.starts_with(item[0]) {
             re = String::from_utf8(item[1].to_vec()).unwrap();
             break;


### PR DESCRIPTION
Summary of work:

 - Added new option `-I` for cutting the cord
 - Added new option `-c` for ignoring styles
 - Added new option `-f` for disabling iframes
 - Changed icons' `href` attribute to be `""` instead of empty PNG when `--no-images` is provided
 - Enabled format check in the pipeline
 - Added more tests

Resolves #6 