### PR TITLE
Added loading of the links given as url(...) in css files

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -8,7 +8,7 @@ use html5ever::{local_name, namespace_url, ns};
 use http::retrieve_asset;
 use js::attr_is_event_handler;
 use std::default::Default;
-use utils::{data_to_dataurl, is_valid_url, resolve_url, url_has_protocol};
+use utils::{data_to_dataurl, is_valid_url, resolve_url, url_has_protocol, resolve_css_imports};
 
 lazy_static! {
     static ref EMPTY_STRING: String = String::new();
@@ -127,7 +127,7 @@ pub fn walk_and_embed_assets(
                                             .unwrap_or(EMPTY_STRING.clone());
                                     let (css_dataurl, _) = retrieve_asset(
                                         &href_full_url,
-                                        true,
+                                        false,
                                         "text/css",
                                         opt_user_agent,
                                         opt_silent,
@@ -135,7 +135,17 @@ pub fn walk_and_embed_assets(
                                     )
                                     .unwrap_or((EMPTY_STRING.clone(), EMPTY_STRING.clone()));
                                     attr.value.clear();
-                                    attr.value.push_slice(css_dataurl.as_str());
+
+                                    let css_resolved = resolve_css_imports(
+                                        &css_dataurl,
+                                        &href_full_url,
+                                        opt_user_agent,
+                                        opt_silent,
+                                        opt_insecure,
+                                    )
+                                    .unwrap_or(css_dataurl);
+
+                                    attr.value.push_slice(css_resolved.as_str());
                                 }
                             }
                         }

--- a/src/html.rs
+++ b/src/html.rs
@@ -8,7 +8,7 @@ use html5ever::{local_name, namespace_url, ns};
 use http::retrieve_asset;
 use js::attr_is_event_handler;
 use std::default::Default;
-use utils::{data_to_dataurl, is_valid_url, resolve_url, url_has_protocol, resolve_css_imports};
+use utils::{data_to_dataurl, is_valid_url, resolve_css_imports, resolve_url, url_has_protocol};
 
 lazy_static! {
     static ref EMPTY_STRING: String = String::new();

--- a/src/http.rs
+++ b/src/http.rs
@@ -45,11 +45,11 @@ pub fn retrieve_asset(
             };
 
             Ok((
-                data_to_dataurl(&mimetype, &data),
+                if response.status() != 200 { "".to_string() } else { data_to_dataurl(&mimetype, &data) },
                 response.url().to_string(),
             ))
         } else {
-            Ok((response.text().unwrap(), response.url().to_string()))
+            Ok((if response.status() != 200 { "".to_string() } else {  response.text().unwrap() }, response.url().to_string()))
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -45,11 +45,22 @@ pub fn retrieve_asset(
             };
 
             Ok((
-                if response.status() != 200 { "".to_string() } else { data_to_dataurl(&mimetype, &data) },
+                if response.status() != 200 {
+                    "".to_string()
+                } else {
+                    data_to_dataurl(&mimetype, &data)
+                },
                 response.url().to_string(),
             ))
         } else {
-            Ok((if response.status() != 200 { "".to_string() } else {  response.text().unwrap() }, response.url().to_string()))
+            Ok((
+                if response.status() != 200 {
+                    "".to_string()
+                } else {
+                    response.text().unwrap()
+                },
+                response.url().to_string(),
+            ))
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 extern crate base64;
 
 use self::base64::encode;
-use regex::Regex;
 use http::retrieve_asset;
+use regex::Regex;
 use url::{ParseError, Url};
 
 lazy_static! {
@@ -83,14 +83,25 @@ pub fn resolve_url(from: &str, to: &str) -> Result<String, ParseError> {
     Ok(result)
 }
 
-pub fn resolve_css_imports(css_string: &str, href: &str, opt_user_agent: &str, opt_silent: bool, opt_insecure: bool) -> Result<String, String> {
+pub fn resolve_css_imports(
+    css_string: &str,
+    href: &str,
+    opt_user_agent: &str,
+    opt_silent: bool,
+    opt_insecure: bool,
+) -> Result<String, String> {
     let mut resolved_css = String::from(css_string);
-    let re = Regex::new(r###"url\((?:(?:https?|ftp)://)?"?[\w/\-?=%.]+\.[\w/\-?=%.]+"?\)"###).unwrap();
-    
+    let re =
+        Regex::new(r###"url\((?:(?:https?|ftp)://)?"?[\w/\-?=%.]+\.[\w/\-?=%.]+"?\)"###).unwrap();
+
     for link in re.captures_iter(&css_string) {
-        let target_link = if link[0].chars().nth(4) == Some('"') { &link[0][5..link[0].len()-2] } else {&link[0][4..link[0].len()-1]};
+        let target_link = if link[0].chars().nth(4) == Some('"') {
+            &link[0][5..link[0].len() - 2]
+        } else {
+            &link[0][4..link[0].len() - 1]
+        };
         let embedded_url = String::from([href, "/../", &target_link.to_string()].concat());
-        
+
         let (css_dataurl, _) = retrieve_asset(
             &embedded_url,
             true, // true
@@ -100,9 +111,18 @@ pub fn resolve_css_imports(css_string: &str, href: &str, opt_user_agent: &str, o
             opt_insecure,
         )
         .unwrap_or((EMPTY_STRING.clone(), EMPTY_STRING.clone()));
-        
-        let replacement = &["\"",  &css_dataurl.replace("\"",&["\\", "\""].concat()).to_string(), "\""].concat();
-        let t = resolved_css.replace(&link[0][4..link[0].len() - 1], &replacement).to_string();
+
+        let replacement = &[
+            "\"",
+            &css_dataurl
+                .replace("\"", &["\\", "\""].concat())
+                .to_string(),
+            "\"",
+        ]
+        .concat();
+        let t = resolved_css
+            .replace(&link[0][4..link[0].len() - 1], &replacement)
+            .to_string();
         resolved_css = t.clone();
     }
 


### PR DESCRIPTION
This PR addresses #59 and #2 and allows to load files linked in stylesheets.

For now it is implemented only for external stylesheet files, though not ready for merge, but I would appreciate if you @snshn could review the approach and if it matches what you'd like to see for this project.

Initially I looked at `rust-cssparser` by servo. It's cool framework, but as for me it's a bit overcomplicated for the purpose of just loading external dependencies. So, for now I'd go with regular expressions, as they do cover the limited subset of 'parsing' we need for this feature.

Would be glad to hear your feedback.