### PR TITLE
Add support for lazy loaded images

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -158,7 +158,7 @@ pub fn walk_and_embed_assets(
                 }
                 "img" => {
                     for attr in attrs_mut.iter_mut() {
-                        if &attr.name.local == "src" {
+                        if &attr.name.local == "src" || &attr.name.local == "data-src" {
                             let value = attr.value.to_string();
 
                             // Ignore images with empty source


### PR DESCRIPTION
The way this patch works is by resolving any `data-src` tags on images in
the same way as normal source tags are resolved.  It is assumed that most
lazy-load libraries will use this tag, and that if this tag is set, then it is a
URL that is in use.

I'm not sure if this is an oversimple solution, but it does seem to resolve lazy loading the the two sites given in the PR that this would close, #16.