### PR TITLE
use clean URLs as hashmap keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_script:
     - rustup component add rustfmt
 
 script:
-   - cargo build --all --locked --verbose
-   - cargo test --all --locked --verbose
-   - cargo fmt --all -- --check
+    - cargo build --all --locked --verbose
+    - cargo test --all --locked --verbose
+    - cargo fmt --all -- --check
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,24 @@ cache: cargo
 sudo: false
 
 os:
-    - linux
-    - osx
+  - linux
+  - osx
 
 rust:
-    - stable
-    - beta
-    - nightly
+  - stable
+  - beta
+  - nightly
 
 before_script:
-    - rustup component add rustfmt
+  - rustup component add rustfmt
 
 script:
-    - cargo build --all --locked --verbose
-    - cargo test --all --locked --verbose
-    - cargo fmt --all -- --check
+  - cargo build --all --locked --verbose
+  - cargo test --all --locked --verbose
+  - cargo fmt --all -- --check
 
 jobs:
   allow_failures:
+    - rust: beta
     - rust: nightly
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,6 +94,7 @@ environment:
 # or test failure in the matching channels/targets from failing the entire build.
 matrix:
   allow_failures:
+    - channel: beta
     - channel: nightly
 
 # If you only care about stable channel build failures, uncomment the following line:

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -1,5 +1,6 @@
 use crate::utils::{
-    data_to_dataurl, detect_mimetype, is_data_url, is_valid_url, resolve_url, url_has_protocol,
+    clean_url, data_to_dataurl, detect_mimetype, is_data_url, is_valid_url, resolve_url,
+    url_has_protocol,
 };
 use url::ParseError;
 
@@ -157,4 +158,20 @@ fn test_is_data_url() {
     assert!(!is_data_url("https://kernel.org").unwrap_or(false));
     assert!(!is_data_url("//kernel.org").unwrap_or(false));
     assert!(!is_data_url("").unwrap_or(false));
+}
+
+#[test]
+fn test_clean_url() {
+    assert_eq!(
+        clean_url("https://somewhere.com/font.eot#iefix"),
+        "https://somewhere.com/font.eot"
+    );
+    assert_eq!(
+        clean_url("https://somewhere.com/font.eot#"),
+        "https://somewhere.com/font.eot"
+    );
+    assert_eq!(
+        clean_url("https://somewhere.com/font.eot?#"),
+        "https://somewhere.com/font.eot"
+    );
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -196,3 +196,14 @@ pub fn resolve_css_imports(
         resolved_css
     }
 }
+
+pub fn clean_url<T: AsRef<str>>(url: T) -> String {
+    let mut result = Url::parse(url.as_ref()).unwrap();
+    // Clear fragment
+    result.set_fragment(None);
+    // Get rid of stray question mark
+    if result.query() == Some("") {
+        result.set_query(None);
+    }
+    result.to_string()
+}


### PR DESCRIPTION
This solves the problem that can often be seen where web fonts get included using IE6-8 fix that has duplicate font URL in CSS with `?#` at the end. Caching should always exclude fragment (`#...`) since it never gets sent over the network, however I'm still on the fence with r-trimming empty query (`?`), as I'm not entirely sure the server sees the same request with a question mark at the end as without.