### PR TITLE
Migrate to Rust2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Mahdi Robatipoor <mahdi.robatipoor@gmail.com>",
     "Emmanuel Delaborde <th3rac25@gmail.com>",
     "Emi Simpson <emi@alchemi.dev>",
+    "rhysd <lin90162@yahoo.co.jp>",
 ]
 description = "CLI tool for saving web pages as a single HTML file"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "monolith"
 version = "2.1.1"
+edition = "2018"
 authors = [
     "Sunshine <sunshine@uberspace.net>",
     "Mahdi Robatipoor <mahdi.robatipoor@gmail.com>",

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,3 +1,8 @@
+use crate::http::retrieve_asset;
+use crate::js::attr_is_event_handler;
+use crate::utils::{
+    data_to_dataurl, is_valid_url, resolve_css_imports, resolve_url, url_has_protocol,
+};
 use html5ever::interface::QualName;
 use html5ever::parse_document;
 use html5ever::rcdom::{Handle, NodeData, RcDom};
@@ -5,12 +10,9 @@ use html5ever::serialize::{serialize, SerializeOpts};
 use html5ever::tendril::{format_tendril, Tendril, TendrilSink};
 use html5ever::tree_builder::{Attribute, TreeSink};
 use html5ever::{local_name, namespace_url, ns};
-use http::retrieve_asset;
-use js::attr_is_event_handler;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::default::Default;
-use utils::{data_to_dataurl, is_valid_url, resolve_css_imports, resolve_url, url_has_protocol};
 
 const ICON_VALUES: [&str; 5] = [
     "icon",

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,7 +1,7 @@
+use crate::utils::{clean_url, data_to_dataurl, is_data_url};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 use std::collections::HashMap;
-use utils::{clean_url, data_to_dataurl, is_data_url};
 
 pub fn retrieve_asset(
     cache: &mut HashMap<String, String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,5 @@
-extern crate html5ever;
 #[macro_use]
 extern crate lazy_static;
-extern crate regex;
-extern crate reqwest;
-extern crate url;
 
 #[macro_use]
 mod macros;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,10 @@
 #[macro_use]
 extern crate clap;
-extern crate monolith;
-extern crate reqwest;
 
 mod args;
 mod macros;
 
-use args::AppArgs;
+use crate::args::AppArgs;
 use monolith::html::{html_to_dom, stringify_document, walk_and_embed_assets};
 use monolith::http::retrieve_asset;
 use monolith::utils::is_valid_url;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,5 @@
-extern crate base64;
-
-use self::base64::encode;
-use http::retrieve_asset;
+use crate::http::retrieve_asset;
+use base64::encode;
 use regex::Regex;
 use reqwest::Client;
 use std::collections::HashMap;


### PR DESCRIPTION
This PR migrates monolith to [Rust2018 edition](https://doc.rust-lang.org/stable/edition-guide/rust-2018/edition-changes.html) from current old Rust2015 edition. Rust2018 is a newer spec of Rust programming language as you know. Changes are mainly for module imports/exports and done by `cargo fix --edition`/`cargo fix --edition-idioms`.

I confirmed `cargo run` works the same as previous and all tests passed.