### PR TITLE
Add a comment indicating the context under which a page was downloaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ lazy_static = "1.4.0"
 regex = "1.3.1"
 url = "2.1.0"
 
+# Used to render comments indicating the time the page was saved
+# also required by reqwest as of v0.10.0
+time = "0.1.42"
+
 [dependencies.reqwest]
 version = "0.10.*"
 default-features = false

--- a/src/args.rs
+++ b/src/args.rs
@@ -12,6 +12,7 @@ pub struct AppArgs {
     pub output: String,
     pub silent: bool,
     pub user_agent: String,
+    pub no_context: bool,
 }
 
 const DEFAULT_USER_AGENT: &str =
@@ -31,6 +32,7 @@ impl AppArgs {
                     .help("URL to download"),
             )
             // .args_from_usage("-a, --include-audio 'Embed audio sources'")
+            .args_from_usage("-C, --no-context 'Exclude time and original URL in output'")
             .args_from_usage("-c, --no-css 'Ignore styles'")
             .args_from_usage("-f, --no-frames 'Exclude iframes'")
             .args_from_usage("-i, --no-images 'Remove images'")
@@ -48,6 +50,7 @@ impl AppArgs {
             .value_of("url")
             .expect("please set target url")
             .to_string();
+        app_args.no_context = app.is_present("no-context");
         app_args.no_css = app.is_present("no-css");
         app_args.no_frames = app.is_present("no-frames");
         app_args.no_images = app.is_present("no-images");

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,16 +95,18 @@ fn main() {
             app_args.isolate,
         );
 
-        html.insert_str(
-            0,
-            &format!(
-                "<!--- Downloaded from {} on {}using {} v{} -->\n",
-                &final_url,
-                downloaded_time.to_local().rfc822(),
-                env!("CARGO_PKG_NAME"),
-                env!("CARGO_PKG_VERSION"),
-            ),
-        );
+        if !app_args.no_context {
+            html.insert_str(
+                0,
+                &format!(
+                    "<!--- Downloaded from {} on {}using {} v{} -->\n",
+                    &final_url,
+                    downloaded_time.rfc822(),
+                    env!("CARGO_PKG_NAME"),
+                    env!("CARGO_PKG_VERSION"),
+                ),
+            );
+        }
 
         if app_args.output == str!() {
             println!("{}", html);

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use monolith::http::retrieve_asset;
 use monolith::utils::is_valid_url;
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::Url;
 use std::collections::HashMap;
 use std::fs::{remove_file, File};
 use std::io::{Error, Write};
@@ -96,11 +97,17 @@ fn main() {
         );
 
         if !app_args.no_context {
+            // Safe to unwrap: We just put this through an HTTP request
+            let mut clean_url = Url::parse(&final_url).unwrap();
+            clean_url.set_fragment(None);
+            // Safe to unwrap: must have a protocol and thus base 'cause we just used it.
+            clean_url.set_password(None).unwrap();
+            clean_url.set_username("").unwrap();
             html.insert_str(
                 0,
                 &format!(
                     "<!--- Downloaded from {} on {}using {} v{} -->\n",
-                    &final_url,
+                    &clean_url,
                     downloaded_time.rfc822(),
                     env!("CARGO_PKG_NAME"),
                     env!("CARGO_PKG_VERSION"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
             app_args.silent,
         )
         .unwrap();
-        let downloaded_time = time::now();
+        let downloaded_time = time::now_utc();
         let dom = html_to_dom(&data);
 
         walk_and_embed_assets(
@@ -106,9 +106,9 @@ fn main() {
             html.insert_str(
                 0,
                 &format!(
-                    "<!--- Downloaded from {} on {}using {} v{} -->\n",
+                    "<!--- Downloaded from {} on {} using {} v{} -->\n",
                     &clean_url,
-                    downloaded_time.rfc822(),
+                    downloaded_time.rfc3339(),
                     env!("CARGO_PKG_NAME"),
                     env!("CARGO_PKG_VERSION"),
                 ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ fn main() {
             app_args.silent,
         )
         .unwrap();
+        let downloaded_time = time::now();
         let dom = html_to_dom(&data);
 
         walk_and_embed_assets(
@@ -85,13 +86,24 @@ fn main() {
             app_args.no_frames,
         );
 
-        let html: String = stringify_document(
+        let mut html: String = stringify_document(
             &dom.document,
             app_args.no_css,
             app_args.no_frames,
             app_args.no_js,
             app_args.no_images,
             app_args.isolate,
+        );
+
+        html.insert_str(
+            0,
+            &format!(
+                "<!--- Downloaded from {} on {}using {} v{} -->\n",
+                &final_url,
+                downloaded_time.to_local().rfc822(),
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION"),
+            ),
         );
 
         if app_args.output == str!() {


### PR DESCRIPTION
Currently, monolith leaves very little trace of where a page came from, or any other record of the conditions under which a page was saved.

It's very likely that, after a page is saved, a user needs to recall where that page originally came from, possibly because they didn't save a complicated page URL.  They might also need other information about how the page was recorded, such as the date the page was saved (useful if you're trying to determine if/when a page changed, or trying to figure out why a page and its monolith differ) and the version of monolith that was used to save it (useful if you're trying to decide whether or not to redownload a page with an updated version of monolith, for example).

This pull request prepends a short comment to the beginning of each downloaded page noting the page URL, the current date, and the version of monolith.  For example:
```html
<!--- Downloaded from https://example.com/ on Wed, 08 Jan 2020 19:22:30 using monolith v2.1.1 -->
```
This comment is added to all pages by default, but in the event that a user wants their page modified only minimally, this option can be disable via the `-C/--no-comment` option, which applies monolith's current behavior.

This change adds another direct dependency (`time-0.1.42`) in order to render the timestamp.  However, I don't think this is itself worth avoiding, since `time` is already a requirement of several other dependencies.  Because of this, the release binary only grows by ~14.8 kB (0.15%).