### PR TITLE
Update snapcraft configuration

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: monolith
 base: core18 
-version: git
+# Version data defined inside the monolith part below
+adopt-info: monolith
 summary: Monolith - Save HTML pages with ease 
 description: |
   A data hoarder's dream come true: bundle any web page into a single
@@ -17,6 +18,14 @@ description: |
 
 confinement: strict
 
+# Building on armhf fails, so we specify all supported non-armhf architectures
+architectures:
+  - build-on: amd64
+  - build-on: i386
+  - build-on: arm64
+  - build-on: ppc64el
+  - build-on: s390x
+
 parts:
   monolith:
     plugin: rust
@@ -24,6 +33,21 @@ parts:
     build-packages:
       - libssl-dev
       - pkg-config
+    override-pull: |
+      snapcraftctl pull
+      # Determine the current tag
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      # Determine the most recent version in the beta channel in the Snap Store
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      # set version number of the snap based on what we did above
+      snapcraftctl set-version $(git describe --tags --abbrev=0)
 
 apps:
   monolith:


### PR DESCRIPTION
This changes the build slightly. If snapcraft is triggered when there is a new tagged release in the project github release page, and it's newer than the version in the Snap Store beta channel, we build that stable release. If however, the latest stable release in github releases is already the same as the Snap Store beta channel, then we build the tip of master.

This gives a couple of advantages. 

  * One yaml can be used to build tip-of-git snaps, and stable releases alike
  * Closing the beta channel in the Snap Store will mean the next triggered build will re-build whatever the last stable release is. This is useful to force a rebuild of the stable version in case a dependency (not that there are many) has a security issue.

We also now set the version dynamically based on the git tags.