### PR TITLE
Support HTTP and HTTPS proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ If compared to saving websites with `wget -mpk`, this tool embeds all assets as 
  - `-u`: Specify custom User-Agent
 
 ## HTTPS and HTTP proxies
-
-Please set `$https_proxy` and `$http_proxy` environment variables.
+Please set `https_proxy` and `http_proxy` environment variables.
 
 ## Related projects
  - `Pagesaver`: https://github.com/distributed-mind/pagesaver

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ If compared to saving websites with `wget -mpk`, this tool embeds all assets as 
  - `-s`: Silent mode
  - `-u`: Specify custom User-Agent
 
+## HTTPS and HTTP proxies
+
+Please set `$https_proxy` and `$http_proxy` environment variables.
+
 ## Related projects
  - `Pagesaver`: https://github.com/distributed-mind/pagesaver
  - `SingleFile`: https://github.com/gildas-lormeau/SingleFile

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,15 +59,19 @@ fn create_http_client(args: &AppArgs) -> Result<Client, reqwest::Error> {
         .default_headers(header_map);
 
     if let Ok(var) = env::var("https_proxy").or_else(|_| env::var("HTTPS_PROXY")) {
-        let proxy = Proxy::https(&var)
-            .expect("Could not set HTTPS proxy. Please check $https_proxy env var");
-        builder = builder.proxy(proxy);
+        if !var.is_empty() {
+            let proxy = Proxy::https(&var)
+                .expect("Could not set HTTPS proxy. Please check $https_proxy env var");
+            builder = builder.proxy(proxy);
+        }
     }
 
     if let Ok(var) = env::var("http_proxy").or_else(|_| env::var("HTTP_PROXY")) {
-        let proxy =
-            Proxy::http(&var).expect("Could not set HTTP proxy. Please check $http_proxy env var");
-        builder = builder.proxy(proxy);
+        if !var.is_empty() {
+            let proxy = Proxy::http(&var)
+                .expect("Could not set HTTP proxy. Please check $http_proxy env var");
+            builder = builder.proxy(proxy);
+        }
     }
 
     builder.build()


### PR DESCRIPTION
Fixes #103 

With this PR `monolith` command will look `$https_proxy` and `$http_proxy` environment variables like other major CLI tools (e.g. `pip`, `apt`, ...).