### PR TITLE
Revert #106 since reqwest supports system proxies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ If compared to saving websites with `wget -mpk`, this tool embeds all assets as 
  - `-s`: Silent mode
  - `-u`: Specify custom User-Agent
 
+## HTTPS and HTTP proxies
+Please set `https_proxy`, `http_proxy` and `no_proxy` environment variables.
+
 ## Related projects
  - `Pagesaver`: https://github.com/distributed-mind/pagesaver
  - `SingleFile`: https://github.com/gildas-lormeau/SingleFile

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ If compared to saving websites with `wget -mpk`, this tool embeds all assets as 
  - `-s`: Silent mode
  - `-u`: Specify custom User-Agent
 
-## HTTPS and HTTP proxies
-Please set `https_proxy` and `http_proxy` environment variables.
-
 ## Related projects
  - `Pagesaver`: https://github.com/distributed-mind/pagesaver
  - `SingleFile`: https://github.com/gildas-lormeau/SingleFile

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,7 @@ use monolith::http::retrieve_asset;
 use monolith::utils::is_valid_url;
 use reqwest::blocking::Client;
 use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
-use reqwest::Proxy;
 use std::collections::HashMap;
-use std::env;
 use std::fs::File;
 use std::io::{self, Error, Write};
 use std::process;
@@ -46,37 +44,6 @@ impl Output {
     }
 }
 
-fn create_http_client(args: &AppArgs) -> Result<Client, reqwest::Error> {
-    let mut header_map = HeaderMap::new();
-    header_map.insert(
-        USER_AGENT,
-        HeaderValue::from_str(&args.user_agent).expect("Invalid User-Agent header specified"),
-    );
-
-    let mut builder = Client::builder()
-        .timeout(Duration::from_secs(10))
-        .danger_accept_invalid_certs(args.insecure)
-        .default_headers(header_map);
-
-    if let Ok(var) = env::var("https_proxy").or_else(|_| env::var("HTTPS_PROXY")) {
-        if !var.is_empty() {
-            let proxy = Proxy::https(&var)
-                .expect("Could not set HTTPS proxy. Please check $https_proxy env var");
-            builder = builder.proxy(proxy);
-        }
-    }
-
-    if let Ok(var) = env::var("http_proxy").or_else(|_| env::var("HTTP_PROXY")) {
-        if !var.is_empty() {
-            let proxy = Proxy::http(&var)
-                .expect("Could not set HTTP proxy. Please check $http_proxy env var");
-            builder = builder.proxy(proxy);
-        }
-    }
-
-    builder.build()
-}
-
 fn main() {
     let app_args = AppArgs::get();
 
@@ -89,8 +56,21 @@ fn main() {
     }
 
     let mut output = Output::new(&app_args.output).expect("Could not prepare output");
+
+    // Initialize client
     let mut cache = HashMap::new();
-    let client = create_http_client(&app_args).expect("Failed to initialize HTTP client");
+    let mut header_map = HeaderMap::new();
+    header_map.insert(
+        USER_AGENT,
+        HeaderValue::from_str(&app_args.user_agent).expect("Invalid User-Agent header specified"),
+    );
+
+    let client = Client::builder()
+        .timeout(Duration::from_secs(10))
+        .danger_accept_invalid_certs(app_args.insecure)
+        .default_headers(header_map)
+        .build()
+        .expect("Failed to initialize HTTP client");
 
     // Retrieve root document
     let (data, final_url) = retrieve_asset(


### PR DESCRIPTION
This PR reverts #106 and adds small instruction to README.md for proxies.

After #106 was merged, I've found that reqwest supports HTTP and HTTPS proxies by default. We don't need to add any code to support it. It means that they are already supported in current version.

Though I'm not under proxy environment, I confirmed `$https_proxy` is referred by confirming an error:

```
> https_proxy=http://localhost cargo run -- https://example.com
thread 'main' panicked at 'Could not retrieve assets in HTML: reqwest::Error { kind: Request, url: "https://example.com/", source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })) }', src/libcore/result.rs:1165:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

(Of course without specifying `$https_proxy` works without error)

It is enabled here:

https://github.com/seanmonstar/reqwest/blob/4c1290fc2af11a766d823c82616338d0ae6a2a6d/src/async_impl/client.rs#L154-L156

And `Proxy` instances are generated here in through `Proxy::system()` and `Proxy::get_from_environment`:

https://github.com/seanmonstar/reqwest/blob/4c1290fc2af11a766d823c82616338d0ae6a2a6d/src/proxy.rs#L596-L614

And the flag `auto_sys_proxy` is set to `true` by default here:

https://github.com/seanmonstar/reqwest/blob/4c1290fc2af11a766d823c82616338d0ae6a2a6d/src/async_impl/client.rs#L118

Ref: #103 