### PR TITLE
Add armhf target to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,8 +21,9 @@ confinement: strict
 # Building on armhf fails, so we specify all supported non-armhf architectures
 architectures:
   - build-on: amd64
-  - build-on: i386
   - build-on: arm64
+  - build-on: armhf
+  - build-on: i386
   - build-on: ppc64el
   - build-on: s390x
 


### PR DESCRIPTION
@popey hey Alan, could you please check to see if it builds now on armhf if you get a minute? I remember there were some issues with it -- was wondering if the new(er) version of Rust and dependencies makes it go smooth now.