### PR TITLE
Update Cargo.toml for publishing on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "monolith"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "monolith"
-version = "2.3.1"
-edition = "2018"
+version = "2.4.0"
 authors = [
     "Sunshine <sunshine@uberspace.net>",
     "Mahdi Robatipoor <mahdi.robatipoor@gmail.com>",
@@ -9,7 +8,19 @@ authors = [
     "Emi Simpson <emi@alchemi.dev>",
     "rhysd <lin90162@yahoo.co.jp>",
 ]
+edition = "2018"
 description = "CLI tool for saving web pages as a single HTML file"
+homepage = "https://github.com/Y2Z/monolith"
+repository = "https://github.com/Y2Z/monolith"
+readme = "README.md"
+keywords = ["web", "http", "https", "html", "download", "command-line", "tool", "data-url"]
+categories = ["command-line-utilities", "web-programming"]
+include = [
+    "src/*.rs",
+    "Cargo.toml",
+]
+license = "The Unlicense"
+license-file = "LICENSE"
 
 [dependencies]
 base64 = "0.13.0"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ If compared to saving websites with `wget -mpk`, this tool embeds all assets as 
 
 ## Installation
 
+### Using Cargo
+    $ cargo install monolith
+
 #### Via Homebrew (on macOS and GNU/Linux)
     $ brew install monolith
 


### PR DESCRIPTION
Also bumps project version number to 2.4.0
