### PR TITLE
Remove optional trailing space from CSS idents

### DIFF
--- a/src/css.rs
+++ b/src/css.rs
@@ -66,6 +66,7 @@ pub fn enquote(input: String, double: bool) -> String {
 pub fn format_ident(ident: &str) -> String {
     let mut res: String = String::new();
     let _ = serialize_identifier(ident, &mut res);
+    res = res.trim_end().to_string();
     res
 }
 

--- a/src/tests/css/embed_css.rs
+++ b/src/tests/css/embed_css.rs
@@ -340,4 +340,31 @@ mod passing {
             CSS_OUT
         );
     }
+
+    #[test]
+    fn ie_css_hack() {
+        let cache = &mut HashMap::new();
+        let client = Client::new();
+        let document_url: Url = Url::parse("data:,").unwrap();
+        let mut options = Options::default();
+        options.silent = true;
+
+        const CSS: &str = "\
+            div#p>svg>foreignObject>section:not(\\9) {\n\
+                width: 300px;\n\
+                width: 500px\\9;\n\
+            }\n\
+            ";
+        const CSS_OUT: &str = "\
+            div#p>svg>foreignObject>section:not(\\9) {\n\
+                width: 300px;\n\
+                width: 500px\t;\n\
+            }\n\
+            ";
+
+        assert_eq!(
+            css::embed_css(cache, &client, &document_url, &CSS, &options, 0,),
+            CSS_OUT
+        );
+    }
 }


### PR DESCRIPTION
Resolves #258 