### PR TITLE
Add simple support for cookies and base_auth

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use encoding_rs::Encoding;
 use html5ever::rcdom::RcDom;
 use reqwest::blocking::Client;
-use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT, COOKIE};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, prelude::*, Error, Write};
@@ -153,6 +153,12 @@ fn main() {
         header_map.insert(
             USER_AGENT,
             HeaderValue::from_str(&user_agent).expect("Invalid User-Agent header specified"),
+        );
+    }
+    if let Some(cookies) = &options.cookies {
+        header_map.insert(
+            COOKIE,
+            HeaderValue::from_str(&cookies).expect("Invalid cookies specified"),
         );
     }
     let client = if options.timeout > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use encoding_rs::Encoding;
 use html5ever::rcdom::RcDom;
 use reqwest::blocking::Client;
-use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT, COOKIE};
+use reqwest::header::{HeaderMap, HeaderValue, USER_AGENT, COOKIE, AUTHORIZATION};
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, prelude::*, Error, Write};
@@ -159,6 +159,16 @@ fn main() {
         header_map.insert(
             COOKIE,
             HeaderValue::from_str(&cookie).expect("Invalid cookie specified"),
+        );
+    }
+    if let Some(base_auth) = &options.base_auth {
+        if !base_auth.contains(":") {
+            panic!("base-auth doesn't have a colon. The format for base_auth must be 'username:password'.")
+        }
+        let credentials = format!("Basic {}", base64::encode(base_auth));
+        header_map.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&credentials).expect("Invalid base-auth specified"),
         );
     }
     let client = if options.timeout > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,10 +155,10 @@ fn main() {
             HeaderValue::from_str(&user_agent).expect("Invalid User-Agent header specified"),
         );
     }
-    if let Some(cookies) = &options.cookies {
+    if let Some(cookie) = &options.cookie {
         header_map.insert(
             COOKIE,
-            HeaderValue::from_str(&cookies).expect("Invalid cookies specified"),
+            HeaderValue::from_str(&cookie).expect("Invalid cookie specified"),
         );
     }
     let client = if options.timeout > 0 {

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -23,7 +23,7 @@ pub struct Options {
     pub target: String,
     pub no_color: bool,
     pub unwrap_noscript: bool,
-    pub cookies: Option<String>,
+    pub cookie: Option<String>,
 }
 
 const ASCII: &'static str = " \
@@ -69,7 +69,7 @@ impl Options {
             .args_from_usage("-t, --timeout=[60] 'Adjusts network request timeout'")
             .args_from_usage("-u, --user-agent=[Firefox] 'Sets custom User-Agent string'")
             .args_from_usage("-v, --no-video 'Removes video sources'")
-            .args_from_usage("--cookies, --cookies=[UTF-8] 'Set cookies for HTTP requests. This format is being used: \"name1=value1;name2=value2\"'")
+            .args_from_usage("--cookie, --cookie=[UTF-8] 'Set cookies for HTTP requests. This format is being used: \"name1=value1;name2=value2\"'")
             .arg(
                 Arg::with_name("target")
                     .required(true)
@@ -124,8 +124,8 @@ impl Options {
             }
         }
 
-        if let Some(cookies) = app.value_of("cookies") {
-            options.cookies = Some(str!(cookies));
+        if let Some(cookie) = app.value_of("cookie") {
+            options.cookie = Some(str!(cookie));
         }
 
         options

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -69,7 +69,7 @@ impl Options {
             .args_from_usage("-t, --timeout=[60] 'Adjusts network request timeout'")
             .args_from_usage("-u, --user-agent=[Firefox] 'Sets custom User-Agent string'")
             .args_from_usage("-v, --no-video 'Removes video sources'")
-            .args_from_usage("--cookies, --cookies=[UTF-8] 'Set cookies for HTTP requests. This format is being used: name1=value1;name2=value2'")
+            .args_from_usage("--cookies, --cookies=[UTF-8] 'Set cookies for HTTP requests. This format is being used: \"name1=value1;name2=value2\"'")
             .arg(
                 Arg::with_name("target")
                     .required(true)

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -23,6 +23,7 @@ pub struct Options {
     pub target: String,
     pub no_color: bool,
     pub unwrap_noscript: bool,
+    pub cookies: Option<String>,
 }
 
 const ASCII: &'static str = " \
@@ -68,6 +69,7 @@ impl Options {
             .args_from_usage("-t, --timeout=[60] 'Adjusts network request timeout'")
             .args_from_usage("-u, --user-agent=[Firefox] 'Sets custom User-Agent string'")
             .args_from_usage("-v, --no-video 'Removes video sources'")
+            .args_from_usage("--cookies, --cookies=[UTF-8] 'Set cookies for HTTP requests. This format is being used: name1=value1;name2=value2'")
             .arg(
                 Arg::with_name("target")
                     .required(true)
@@ -120,6 +122,10 @@ impl Options {
             if term == "dumb" {
                 options.no_color = true;
             }
+        }
+
+        if let Some(cookies) = app.value_of("cookies") {
+            options.cookies = Some(str!(cookies));
         }
 
         options

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -24,6 +24,7 @@ pub struct Options {
     pub no_color: bool,
     pub unwrap_noscript: bool,
     pub cookie: Option<String>,
+    pub base_auth: Option<String>,
 }
 
 const ASCII: &'static str = " \
@@ -70,6 +71,7 @@ impl Options {
             .args_from_usage("-u, --user-agent=[Firefox] 'Sets custom User-Agent string'")
             .args_from_usage("-v, --no-video 'Removes video sources'")
             .args_from_usage("--cookie, --cookie=[UTF-8] 'Set cookies for HTTP requests. This format is being used: \"name1=value1;name2=value2\"'")
+            .args_from_usage("--base-auth, --base-auth=[UTF-8] 'Execute a base authorization. This format is being used: \"username:password\"'")
             .arg(
                 Arg::with_name("target")
                     .required(true)
@@ -126,6 +128,9 @@ impl Options {
 
         if let Some(cookie) = app.value_of("cookie") {
             options.cookie = Some(str!(cookie));
+        }
+        if let Some(base_auth) = app.value_of("base-auth") {
+            options.base_auth = Some(str!(base_auth))
         }
 
         options


### PR DESCRIPTION
Thanks for your work! Monolith is great tool for downloading websites.

But the lack of support for cookies and base_auth prevented me from backuping my personal wiki.
So I've implemented a very simple method to set cookies and base_auth. 
Maybe you are interested in using my code.

Feel free to refuse, change or accept my pull-request.