### PR TITLE
Reduce size of Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,22 @@
-FROM rust
+FROM ekidd/rust-musl-builder as builder
 
-WORKDIR /usr/local/src/
-RUN curl -s https://api.github.com/repos/y2z/monolith/releases/latest \
-    | grep "tarball_url.*\"," \
-    | cut -d '"' -f 4 \
-    | wget -qi - -O monolith.tar.gz
-
+RUN curl -L -o monolith.tar.gz $(curl -s https://api.github.com/repos/y2z/monolith/releases/latest \
+                                 | grep "tarball_url.*\"," \
+                                 | cut -d '"' -f 4)
 RUN tar xfz monolith.tar.gz \
     && mv Y2Z-monolith-* monolith \
     && rm monolith.tar.gz
 
-WORKDIR /usr/local/src/monolith
-RUN ls -a
+WORKDIR monolith/
 RUN make install
 
+
+FROM alpine
+
+RUN apk update && \
+  apk add --no-cache openssl && \
+  rm -rf "/var/cache/apk/*"
+
+COPY --from=builder /home/rust/.cargo/bin/monolith /usr/bin/monolith
 WORKDIR /tmp
-CMD ["/usr/local/cargo/bin/monolith"]
+ENTRYPOINT ["/usr/bin/monolith"]

--- a/utils/run-in-container.sh
+++ b/utils/run-in-container.sh
@@ -7,4 +7,4 @@ if which podman 2>&1 > /dev/null; then
     DOCKER=podman
 fi
 
-$DOCKER run --rm Y2Z/$PROG_NAME $PROG_NAME "$@"
+$DOCKER run --rm Y2Z/$PROG_NAME "$@"


### PR DESCRIPTION
By using a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) the Docker image size can be reduced significantly.
Before it used 1.88GB of disk space now it's only 23.5MB.