### PR TITLE
Include unsafe-eval origin for isolated documents

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -83,7 +83,7 @@ pub fn compose_csp(options: &Options) -> String {
     let mut string_list = vec![];
 
     if options.isolate {
-        string_list.push("default-src 'unsafe-inline' data:;");
+        string_list.push("default-src 'unsafe-eval' 'unsafe-inline' data:;");
     }
 
     if options.no_css {

--- a/tests/cli/data_url.rs
+++ b/tests/cli/data_url.rs
@@ -30,7 +30,7 @@ mod passing {
         assert_eq!(
             String::from_utf8_lossy(&out.stdout),
             "<html><head>\
-            <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-inline' data:;\"></meta>\
+            <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-eval' 'unsafe-inline' data:;\"></meta>\
             </head><body>Hello, World!</body></html>\n"
         );
 

--- a/tests/cli/local_files.rs
+++ b/tests/cli/local_files.rs
@@ -98,7 +98,7 @@ mod passing {
             format!(
                 "\
                 <!DOCTYPE html><html lang=\"en\"><head>\
-                <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-inline' data:; style-src 'none'; script-src 'none'; img-src data:;\"></meta>\n  \
+                <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-eval' 'unsafe-inline' data:; style-src 'none'; script-src 'none'; img-src data:;\"></meta>\n  \
                 <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">\n  \
                 <title>Local HTML file</title>\n  \
                 <link rel=\"stylesheet\" type=\"text/css\">\n  \

--- a/tests/html/compose_csp.rs
+++ b/tests/html/compose_csp.rs
@@ -16,7 +16,10 @@ mod passing {
         options.isolate = true;
         let csp_content = html::compose_csp(&options);
 
-        assert_eq!(csp_content, "default-src 'unsafe-inline' data:;");
+        assert_eq!(
+            csp_content,
+            "default-src 'unsafe-eval' 'unsafe-inline' data:;"
+        );
     }
 
     #[test]
@@ -75,6 +78,6 @@ mod passing {
         options.no_images = true;
         let csp_content = html::compose_csp(&options);
 
-        assert_eq!(csp_content, "default-src 'unsafe-inline' data:; style-src 'none'; font-src 'none'; frame-src 'none'; child-src 'none'; script-src 'none'; img-src data:;");
+        assert_eq!(csp_content, "default-src 'unsafe-eval' 'unsafe-inline' data:; style-src 'none'; font-src 'none'; frame-src 'none'; child-src 'none'; script-src 'none'; img-src data:;");
     }
 }

--- a/tests/html/serialize_document.rs
+++ b/tests/html/serialize_document.rs
@@ -40,7 +40,7 @@ mod passing {
             )),
             "<html>\
                 <head>\
-                    <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-inline' data:;\"></meta>\
+                    <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-eval' 'unsafe-inline' data:;\"></meta>\
                     <title>Isolated document</title>\
                     <link rel=\"something\" href=\"some.css\">\
                     <meta http-equiv=\"Content-Security-Policy\" content=\"default-src https:\">\
@@ -135,7 +135,7 @@ mod passing {
             "<!DOCTYPE html>\
                 <html>\
                     <head>\
-                        <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-inline' data:; style-src 'none'; font-src 'none'; frame-src 'none'; child-src 'none'; script-src 'none'; img-src data:;\"></meta>\
+                        <meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'unsafe-eval' 'unsafe-inline' data:; style-src 'none'; font-src 'none'; frame-src 'none'; child-src 'none'; script-src 'none'; img-src data:;\"></meta>\
                         <title>no-frame no-css no-js no-image isolated document</title>\
                         <meta http-equiv=\"Content-Security-Policy\" content=\"default-src https:\">\
                         <link rel=\"stylesheet\" href=\"some.css\">\


### PR DESCRIPTION
Some websites require this in order to let its JS operate.