### PR TITLE
[SUGGESTION] Preserve remote sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ cat index.html | monolith -aIiFfcMv -b https://original.site/ - > result.html
  - `-M`: Don't add timestamp and URL information
  - `-n`: Extract contents of NOSCRIPT elements
  - `-o`: Write output to `file` (use “-” for STDOUT)
+ - `-p`: Preserve remote sources
  - `-s`: Be quiet
  - `-t`: Adjust `network request timeout`
  - `-u`: Provide custom `User-Agent`

--- a/src/html.rs
+++ b/src/html.rs
@@ -603,6 +603,12 @@ pub fn retrieve_and_embed_asset(
 ) {
     let resolved_url: Url = resolve_url(document_url, attr_value.clone());
 
+    // Keep remote source references intact if requested
+    if options.preserve_remote && (resolved_url.host_str() != document_url.host_str()) {
+        set_node_attr(node, attr_name, Some(resolved_url.to_string()));
+        return;
+    }
+
     match retrieve_asset(
         cache,
         client,

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -16,6 +16,7 @@ pub struct Options {
     pub insecure: bool,
     pub no_metadata: bool,
     pub output: String,
+    pub preserve_remote: bool,
     pub silent: bool,
     pub timeout: u64,
     pub user_agent: Option<String>,
@@ -64,6 +65,7 @@ impl Options {
             .args_from_usage(
                 "-o, --output=[document.html] 'Writes output to <file>, use - for STDOUT'",
             )
+            .args_from_usage("-p, --preserve-remote 'Preserve remote sources'")
             .args_from_usage("-s, --silent 'Suppresses verbosity'")
             .args_from_usage("-t, --timeout=[60] 'Adjusts network request timeout'")
             .args_from_usage("-u, --user-agent=[Firefox] 'Sets custom User-Agent string'")
@@ -100,6 +102,7 @@ impl Options {
         options.insecure = app.is_present("insecure");
         options.no_metadata = app.is_present("no-metadata");
         options.output = app.value_of("output").unwrap_or("").to_string();
+        options.preserve_remote = app.is_present("preserve-remote");
         options.silent = app.is_present("silent");
         options.timeout = app
             .value_of("timeout")


### PR DESCRIPTION
Hi there. Thanks so much for this project.

We've found it helpful at our org to use this to generate a bundled static html file for error/maintenance pages. Since all the assets are included as source/base64, it does not matter if our servers go down, so long as we host this file elsewhere. I know this is slightly different to the purpose you built it for but it has actually proved very useful for this.

However, there is one small enhancement that I think would make a big difference to our use case. I've included the suggestion in this PR. Basically the idea is to skip embedding sources that come from an external host. The thinking behind this is that if certain images/assets are hosted by a CDN, we need not worry about embedding them into a static maintenance page, since they will continue to be served even if our servers are down. This also means that the file size for this generated file is kept as low as possible, and enables the browser to use possibly already cached assets from these CDNs.

I've used the full hostname in the logic to determine what is considered "external" but perhaps only considering the domain part is a better idea—so that different subdomains are still considered internal sources and are embedded? I think this is debatable either way because someone might be using a subdomain as a CNAME to an external CDN provider.

I can see this as being a useful feature for others, hence the PR suggestion.

This is my first time submitting to an open source project, so please forgive me if I have gone about this the wrong way. Let me know if there is anything else I should do.