### PR TITLE
disable unnecessary/unused regex features to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,8 +1202,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,14 @@ cssparser = "0.29.6"
 encoding_rs = "0.8.31"
 html5ever = "0.24.1"
 percent-encoding = "2.1.0"
-regex = "1.6.0" # Used for parsing srcset and NOSCRIPT
 sha2 = "0.10.2" # Used for calculating checksums during integrity checks
 url = "2.2.2"
+
+# Used for parsing srcset and NOSCRIPT
+[dependencies.regex]
+version = "1.6.0"
+default-features = false
+features = ["std", "perf-dfa", "unicode-perl"]
 
 [dependencies.reqwest]
 version = "0.11.11"


### PR DESCRIPTION
This will reduce the monolith binary size by ~15%.