### PR TITLE
🩹 fix README to prevent 'ERROR: failed to solve: invalid reference format: repository name must be lowercase'

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ make install clean
 #### Using [containers](https://www.docker.com/)
 
 ```console
-docker build -t Y2Z/monolith .
+docker build -t y2z/monolith .
 sudo install -b dist/run-in-container.sh /usr/local/bin/monolith
 ```
 

--- a/dist/run-in-container.sh
+++ b/dist/run-in-container.sh
@@ -7,4 +7,4 @@ if which podman 2>&1 > /dev/null; then
     DOCKER=podman
 fi
 
-$DOCKER run --rm Y2Z/$PROG_NAME "$@"
+$DOCKER run --rm y2z/$PROG_NAME "$@"


### PR DESCRIPTION
This PR fixes a minor issue in README:
```
🦎 ✔ ~/dev/github/monolith [master|✔]
11:40 $ docker build -t Y2Z/monolith .
[+] Building 0.0s (0/0)                                                                                                              docker:default
ERROR: failed to solve: invalid reference format: repository name must be lowercase
🦎 ✘-1 ~/dev/github/monolith [master|✔]
11:40 $ docker build -t y2z/monolith .
```