### PR TITLE
Add flox installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ guix install monolith
 nix-env -iA nixpkgs.monolith
 ```
 
+#### Using [Flox](https://flox.dev)
+
+```flox
+flox install monolith
+```
+
 #### Using [Pacman](https://archlinux.org/packages/extra/x86_64/monolith) (Arch Linux)
 
 ```console

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ nix-env -iA nixpkgs.monolith
 
 #### Using [Flox](https://flox.dev)
 
-```flox
+```console
 flox install monolith
 ```
 


### PR DESCRIPTION
Flox can currently install monolith into a development environment, and seems to be working.
The package itself is based on that coming from nixpkgs, and follows it quite closely.
Currently, Flox doesn't have a webpage to preview the package version et al.
So, instead I just linked to the website itself.