### PR TITLE
add HTTP referer header for resource requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Emmanuel Delaborde <th3rac25@gmail.com>",
     "Emi Simpson <emi@alchemi.dev>",
     "rhysd <lin90162@yahoo.co.jp>",
+    "Andriy Rakhnin <a@rakhnin.com>",
 ]
 edition = "2021"
 description = "CLI tool for saving web pages as a single HTML file"

--- a/src/url.rs
+++ b/src/url.rs
@@ -79,6 +79,17 @@ pub fn parse_data_url(url: &Url) -> (String, String, Vec<u8>) {
     (media_type, charset, blob)
 }
 
+pub fn referer_url(url: Url) -> Url {
+    let mut url = url.clone();
+    // https://httpwg.org/specs/rfc9110.html#field.referer
+    // MUST NOT include the fragment and userinfo components of the URI
+    url.set_fragment(None);
+    url.set_username(&"").unwrap();
+    url.set_password(None).unwrap();
+
+    url
+}
+
 pub fn resolve_url(from: &Url, to: &str) -> Url {
     match Url::parse(&to) {
         Ok(parsed_url) => parsed_url,

--- a/src/url.rs
+++ b/src/url.rs
@@ -79,10 +79,10 @@ pub fn parse_data_url(url: &Url) -> (String, String, Vec<u8>) {
     (media_type, charset, blob)
 }
 
-pub fn referer_url(url: Url) -> Url {
+pub fn get_referer_url(url: Url) -> Url {
     let mut url = url.clone();
-    // https://httpwg.org/specs/rfc9110.html#field.referer
-    // MUST NOT include the fragment and userinfo components of the URI
+    // Spec: https://httpwg.org/specs/rfc9110.html#field.referer
+    // Must not include the fragment and userinfo components of the URI
     url.set_fragment(None);
     url.set_username(&"").unwrap();
     url.set_password(None).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,12 +1,12 @@
 use reqwest::blocking::Client;
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, COOKIE};
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, COOKIE, REFERER};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 use url::Url;
 
 use crate::opts::Options;
-use crate::url::{clean_url, parse_data_url};
+use crate::url::{clean_url, parse_data_url, referer_url};
 
 const ANSI_COLOR_RED: &'static str = "\x1b[31m";
 const ANSI_COLOR_RESET: &'static str = "\x1b[0m";
@@ -297,6 +297,13 @@ pub fn retrieve_asset(
                             .insert(COOKIE, HeaderValue::from_str(&cookie_header_value).unwrap());
                     }
                 }
+            }
+            // Add referer header for page resource requests
+            if parent_url != url {
+                headers.insert(
+                    REFERER,
+                    HeaderValue::from_str(referer_url(parent_url.clone()).as_str()).unwrap(),
+                );
             }
             match client.get(url.as_str()).headers(headers).send() {
                 Ok(response) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use url::Url;
 
 use crate::opts::Options;
-use crate::url::{clean_url, parse_data_url, referer_url};
+use crate::url::{clean_url, get_referer_url, parse_data_url};
 
 const ANSI_COLOR_RED: &'static str = "\x1b[31m";
 const ANSI_COLOR_RESET: &'static str = "\x1b[0m";
@@ -302,7 +302,7 @@ pub fn retrieve_asset(
             if parent_url != url {
                 headers.insert(
                     REFERER,
-                    HeaderValue::from_str(referer_url(parent_url.clone()).as_str()).unwrap(),
+                    HeaderValue::from_str(get_referer_url(parent_url.clone()).as_str()).unwrap(),
                 );
             }
             match client.get(url.as_str()).headers(headers).send() {

--- a/tests/url/get_referer_url.rs
+++ b/tests/url/get_referer_url.rs
@@ -13,18 +13,20 @@ mod passing {
 
     #[test]
     fn preserve_original() {
-        let u: Url = Url::parse("https://somewhere.com/font.eot#iefix").unwrap();
-
-        let referer_u: Url = url::referer_url(u.clone());
-
-        assert_eq!(referer_u.as_str(), "https://somewhere.com/font.eot");
-        assert_eq!(u.as_str(), "https://somewhere.com/font.eot#iefix");
+        let original_url: Url = Url::parse("https://somewhere.com/font.eot#iefix").unwrap();
+        let referer_url: Url = url::get_referer_url(original_url.clone());
+        assert_eq!(referer_url.as_str(), "https://somewhere.com/font.eot");
+        assert_eq!(
+            original_url.as_str(),
+            "https://somewhere.com/font.eot#iefix"
+        );
     }
 
     #[test]
     fn removes_fragment() {
         assert_eq!(
-            url::referer_url(Url::parse("https://somewhere.com/font.eot#iefix").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://somewhere.com/font.eot#iefix").unwrap())
+                .as_str(),
             "https://somewhere.com/font.eot"
         );
     }
@@ -32,7 +34,7 @@ mod passing {
     #[test]
     fn removes_empty_fragment() {
         assert_eq!(
-            url::referer_url(Url::parse("https://somewhere.com/font.eot#").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://somewhere.com/font.eot#").unwrap()).as_str(),
             "https://somewhere.com/font.eot"
         );
     }
@@ -40,7 +42,7 @@ mod passing {
     #[test]
     fn removes_empty_fragment_and_keeps_empty_query() {
         assert_eq!(
-            url::referer_url(Url::parse("https://somewhere.com/font.eot?#").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://somewhere.com/font.eot?#").unwrap()).as_str(),
             "https://somewhere.com/font.eot?"
         );
     }
@@ -48,7 +50,8 @@ mod passing {
     #[test]
     fn removes_empty_fragment_and_keeps_query() {
         assert_eq!(
-            url::referer_url(Url::parse("https://somewhere.com/font.eot?a=b&#").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://somewhere.com/font.eot?a=b&#").unwrap())
+                .as_str(),
             "https://somewhere.com/font.eot?a=b&"
         );
     }
@@ -56,7 +59,7 @@ mod passing {
     #[test]
     fn removes_credentials() {
         assert_eq!(
-            url::referer_url(Url::parse("https://cookie:monster@gibson.lan/path").unwrap())
+            url::get_referer_url(Url::parse("https://cookie:monster@gibson.lan/path").unwrap())
                 .as_str(),
             "https://gibson.lan/path"
         );
@@ -65,7 +68,7 @@ mod passing {
     #[test]
     fn removes_empty_credentials() {
         assert_eq!(
-            url::referer_url(Url::parse("https://@gibson.lan/path").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://@gibson.lan/path").unwrap()).as_str(),
             "https://gibson.lan/path"
         );
     }
@@ -73,7 +76,7 @@ mod passing {
     #[test]
     fn removes_empty_username_credentials() {
         assert_eq!(
-            url::referer_url(Url::parse("https://:monster@gibson.lan/path").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://:monster@gibson.lan/path").unwrap()).as_str(),
             "https://gibson.lan/path"
         );
     }
@@ -81,7 +84,7 @@ mod passing {
     #[test]
     fn removes_empty_password_credentials() {
         assert_eq!(
-            url::referer_url(Url::parse("https://cookie@gibson.lan/path").unwrap()).as_str(),
+            url::get_referer_url(Url::parse("https://cookie@gibson.lan/path").unwrap()).as_str(),
             "https://gibson.lan/path"
         );
     }

--- a/tests/url/mod.rs
+++ b/tests/url/mod.rs
@@ -2,4 +2,5 @@ mod clean_url;
 mod create_data_url;
 mod is_url_and_has_protocol;
 mod parse_data_url;
+mod referer_url;
 mod resolve_url;

--- a/tests/url/mod.rs
+++ b/tests/url/mod.rs
@@ -1,6 +1,6 @@
 mod clean_url;
 mod create_data_url;
+mod get_referer_url;
 mod is_url_and_has_protocol;
 mod parse_data_url;
-mod referer_url;
 mod resolve_url;

--- a/tests/url/referer_url.rs
+++ b/tests/url/referer_url.rs
@@ -15,16 +15,16 @@ mod passing {
     fn preserve_original() {
         let u: Url = Url::parse("https://somewhere.com/font.eot#iefix").unwrap();
 
-        let clean_u: Url = url::clean_url(u.clone());
+        let referer_u: Url = url::referer_url(u.clone());
 
-        assert_eq!(clean_u.as_str(), "https://somewhere.com/font.eot");
+        assert_eq!(referer_u.as_str(), "https://somewhere.com/font.eot");
         assert_eq!(u.as_str(), "https://somewhere.com/font.eot#iefix");
     }
 
     #[test]
     fn removes_fragment() {
         assert_eq!(
-            url::clean_url(Url::parse("https://somewhere.com/font.eot#iefix").unwrap()).as_str(),
+            url::referer_url(Url::parse("https://somewhere.com/font.eot#iefix").unwrap()).as_str(),
             "https://somewhere.com/font.eot"
         );
     }
@@ -32,7 +32,7 @@ mod passing {
     #[test]
     fn removes_empty_fragment() {
         assert_eq!(
-            url::clean_url(Url::parse("https://somewhere.com/font.eot#").unwrap()).as_str(),
+            url::referer_url(Url::parse("https://somewhere.com/font.eot#").unwrap()).as_str(),
             "https://somewhere.com/font.eot"
         );
     }
@@ -40,7 +40,7 @@ mod passing {
     #[test]
     fn removes_empty_fragment_and_keeps_empty_query() {
         assert_eq!(
-            url::clean_url(Url::parse("https://somewhere.com/font.eot?#").unwrap()).as_str(),
+            url::referer_url(Url::parse("https://somewhere.com/font.eot?#").unwrap()).as_str(),
             "https://somewhere.com/font.eot?"
         );
     }
@@ -48,16 +48,41 @@ mod passing {
     #[test]
     fn removes_empty_fragment_and_keeps_query() {
         assert_eq!(
-            url::clean_url(Url::parse("https://somewhere.com/font.eot?a=b&#").unwrap()).as_str(),
+            url::referer_url(Url::parse("https://somewhere.com/font.eot?a=b&#").unwrap()).as_str(),
             "https://somewhere.com/font.eot?a=b&"
         );
     }
 
     #[test]
-    fn keeps_credentials() {
+    fn removes_credentials() {
         assert_eq!(
-            url::clean_url(Url::parse("https://cookie:monster@gibson.internet/").unwrap()).as_str(),
-            "https://cookie:monster@gibson.internet/"
+            url::referer_url(Url::parse("https://cookie:monster@gibson.lan/path").unwrap())
+                .as_str(),
+            "https://gibson.lan/path"
+        );
+    }
+
+    #[test]
+    fn removes_empty_credentials() {
+        assert_eq!(
+            url::referer_url(Url::parse("https://@gibson.lan/path").unwrap()).as_str(),
+            "https://gibson.lan/path"
+        );
+    }
+
+    #[test]
+    fn removes_empty_username_credentials() {
+        assert_eq!(
+            url::referer_url(Url::parse("https://:monster@gibson.lan/path").unwrap()).as_str(),
+            "https://gibson.lan/path"
+        );
+    }
+
+    #[test]
+    fn removes_empty_password_credentials() {
+        assert_eq!(
+            url::referer_url(Url::parse("https://cookie@gibson.lan/path").unwrap()).as_str(),
+            "https://gibson.lan/path"
         );
     }
 }


### PR DESCRIPTION
to mimic more-browser-like-behavior on loading page resources. Sometimes their response depends on `referer` header.

e.g. I faced with the problem to load font data for page, because it was protected for "direct" loading, got `401`, but with the `referer` header it looks like request from browser.