### PR TITLE
Link openssl statically - fixes #340

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "encoding_rs",
  "html5ever",
  "markup5ever_rcdom",
+ "openssl",
  "percent-encoding",
  "regex",
  "reqwest",
@@ -908,6 +909,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +925,7 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ markup5ever_rcdom = "0.3.0"  # Used for manipulating DOM
 percent-encoding = "2.3.1"  # Used for encoding URLs
 sha2 = "0.10.8"  # Used for calculating checksums during integrity checks
 url = "2.5.0"  # Used for parsing URLs
+openssl = { version = "0.10.64", features = ["vendored"] }  # Used for making network requests
 
 # Used for parsing srcset and NOSCRIPT
 [dependencies.regex]


### PR DESCRIPTION
```bash
$ ldd ./target/debug/monolith
	linux-vdso.so.1 (0x00007ffcdf3f0000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x0000778480ac4000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007784809db000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000077847f400000)
	/lib64/ld-linux-x86-64.so.2 (0x0000778480b09000)
```

No openssl dynamic link, and the tests pass on my machine.

Unfortunately, it will be necessary to manually keep the openssl version in sync with what reqwest wants.