### PR TITLE
Allow urlencoded data URLs

### DIFF
--- a/tests/cli/basic.rs
+++ b/tests/cli/basic.rs
@@ -109,11 +109,11 @@ mod passing {
 
     @charset "UTF-8";
 
-    @import "data:text/css;base64,Ym9keXtiYWNrZ3JvdW5kLWNvbG9yOiMwMDA7Y29sb3I6I2ZmZn0K";
+    @import "data:text/css,body{background-color%3A%23000%3Bcolor%3A%23fff}%0A";
 
-    @import url("data:text/css;base64,Ym9keXtiYWNrZ3JvdW5kLWNvbG9yOiMwMDA7Y29sb3I6I2ZmZn0K");
+    @import url("data:text/css,body{background-color%3A%23000%3Bcolor%3A%23fff}%0A");
 
-    @import url("data:text/css;base64,Ym9keXtiYWNrZ3JvdW5kLWNvbG9yOiMwMDA7Y29sb3I6I2ZmZn0K");
+    @import url("data:text/css,body{background-color%3A%23000%3Bcolor%3A%23fff}%0A");
 
 </style>
 <meta name="robots" content="none"></meta></head><body></body></html>

--- a/tests/css/embed_css.rs
+++ b/tests/css/embed_css.rs
@@ -175,9 +175,9 @@ mod passing {
             "\
             @charset \"UTF-8\";\n\
             \n\
-            @import \"data:text/css;base64,aHRtbHtiYWNrZ3JvdW5kLWNvbG9yOiMwMDB9\";\n\
+            @import \"data:text/css,html{background-color%3A%23000}\";\n\
             \n\
-            @import url(\"data:text/css;base64,aHRtbHtjb2xvcjojZmZmfQ==\")\n\
+            @import url(\"data:text/css,html{color%3A%23fff}\")\n\
             "
         );
     }

--- a/tests/session/retrieve_asset.rs
+++ b/tests/session/retrieve_asset.rs
@@ -33,7 +33,7 @@ mod passing {
         assert_eq!(&charset, "US-ASCII");
         assert_eq!(
             url::create_data_url(&media_type, &charset, &data, &final_url),
-            Url::parse("data:text/html;base64,dGFyZ2V0").unwrap(),
+            Url::parse("data:text/html,target").unwrap(),
         );
         assert_eq!(
             final_url,
@@ -70,7 +70,7 @@ mod passing {
             .unwrap();
         assert_eq!(&media_type, "text/javascript");
         assert_eq!(&charset, "");
-        let data_url = "data:text/javascript;base64,ZG9jdW1lbnQuYm9keS5zdHlsZS5iYWNrZ3JvdW5kQ29sb3IgPSAiZ3JlZW4iOwpkb2N1bWVudC5ib2R5LnN0eWxlLmNvbG9yID0gInJlZCI7Cg==";
+        let data_url = "data:text/javascript,document.body.style.backgroundColor%20%3D%20%22green%22%3B%0Adocument.body.style.color%20%3D%20%22red%22%3B%0A";
         assert_eq!(
             url::create_data_url(&media_type, &charset, &data, &final_url),
             Url::parse(data_url).unwrap()


### PR DESCRIPTION
This automatically selects urlencoded data URLs if that results in smaller output then base64 encoding them.

This is a kinda stupid idea I had as I saw the size of some really large dumps (for example from comic pages on tapas.io)...

It seems to work... In a sample page from tapas.io, it reduces the final size from 213,233,452 bytes to 170,968,176 bytes, which is about 20% smaller.

The characters which are percent-encoded come from https://datatracker.ietf.org/doc/html/rfc3986#section-2.2, since that is refernced from https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data - I found no concrete list of characters which should be escaped in the data-URL RFC (https://www.rfc-editor.org/rfc/rfc2397) - Additionally, we escape %, so nested data: URLs (PNGs in CSS anyone?) work and `"`, so we don't accidentally close the quotes surrounding the data URL.

I'm not sure if the encoding is correct for exotic (non-UTF8) charsets... Please advise if I should add more tests testing such scenarios.

(PS: Feel free to close this PR if this all sounds too stupid/mad)
