### PR TITLE
fix local inlined svg symbols from embedding entire page

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -989,6 +989,13 @@ pub fn walk(session: &mut Session, document_url: &Url, node: &Handle) {
                         if let Some(use_attr_href_value) = get_node_attr(node, attr_name) {
                             if session.options.no_images {
                                 set_node_attr(node, attr_name, None);
+                            } else if use_attr_href_value.clone().starts_with('#') {
+                                // Relative symbol that resolves to its own URL; keep as-is.
+                                set_node_attr(
+                                    node,
+                                    attr_name,
+                                    Some(use_attr_href_value),
+                                );
                             } else {
                                 let image_asset_url: Url =
                                     resolve_url(document_url, &use_attr_href_value);

--- a/tests/_data_/svg/svg_inline_symbol_use.html
+++ b/tests/_data_/svg/svg_inline_symbol_use.html
@@ -1,0 +1,21 @@
+<html>
+<body>
+  <svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <symbol id="icon-1" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M10 20h4V10h3l-5-6.5L7 10h3v10Z" />
+      </symbol>
+      <symbol id="icon-2" viewBox="0 0 24 24">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M10 20h4V10h3l-5-6.5L7 10h3v10Z" />
+      </symbol>
+    </defs>
+  </svg>
+
+  <button class="tm-votes-lever__button" data-test-id="votes-lever-upvote-button" title="Like" type="button">
+    <svg class="icon">
+      <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-1" href="#icon-1">
+      </use>
+    </svg>
+  </button>
+</body>
+</html>


### PR DESCRIPTION
This prevents SVGs with `xlink:href`/`href` fragments to inlined symbols in the same document from resolving to the full page URL. This addresses an unintended consequence of #435 that results in inflated file size on some sites, the most obvious culprit being allrecipes.com. 

This should also address some of the reports in https://github.com/karakeep-app/karakeep/issues/770

Here are a few examples with default options showing significant reduction in archive size by about 96% with identical rendering (sometimes improved, as the browser will give up if the archive is too large):



| URL         | v2.10.1         | PR                      |
| :----------- | :--------------: | ----------| 
| [Bourbon Carrot Cake](https://www.allrecipes.com/recipe/279597/carrot-bundt-cake-with-orange-bourbon-glaze/) | 252M | 9.5M  |
| [Quick Pasta Sauce](https://www.allrecipes.com/recipe/21455/quick-pasta-sauce/)    | 326M   | 11M|
| [World's Best Lasagna](https://www.allrecipes.com/recipe/23600/worlds-best-lasagna/)    | 487M   | 15M |