### PR TITLE
fix: Adds handling of webmanifest.

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -449,6 +449,7 @@ pub fn detect_media_type_by_file_name(filename: &str) -> String {
             "tif" | "tiff" => "image/tiff",
             "txt" => "text/plain",
             "wav" => "audio/wav",
+            "webmanifest" => "application/manifest+json",
             "webp" => "image/webp",
             "woff" => "font/woff",
             "woff2" => "font/woff2",

--- a/src/html.rs
+++ b/src/html.rs
@@ -31,6 +31,7 @@ pub enum LinkType {
     Favicon,
     Preload,
     Stylesheet,
+    Manifest,
 }
 
 pub struct SrcSetItem<'a> {
@@ -369,6 +370,8 @@ pub fn parse_link_type(link_attr_rel_value: &str) -> Vec<LinkType> {
             types.push(LinkType::Favicon);
         } else if link_attr_rel_type.eq_ignore_ascii_case("apple-touch-icon") {
             types.push(LinkType::AppleTouchIcon);
+        } else if link_attr_rel_type.eq_ignore_ascii_case("manifest") {
+            types.push(LinkType::Manifest);
         }
     }
 
@@ -839,6 +842,19 @@ pub fn walk(session: &mut Session, document_url: &Url, node: &Handle) {
                                 // Wipe integrity attribute
                                 set_node_attr(node, "integrity", None);
                             } else if !link_attr_href_value.is_empty() {
+                                retrieve_and_embed_asset(
+                                    session,
+                                    document_url,
+                                    node,
+                                    "href",
+                                    &link_attr_href_value,
+                                );
+                            }
+                        }
+                    } else if link_node_types.contains(&LinkType::Manifest) {
+                        // Resolve LINK's href attribute
+                        if let Some(link_attr_href_value) = get_node_attr(node, "href") {
+                            if !link_attr_href_value.is_empty() {
                                 retrieve_and_embed_asset(
                                     session,
                                     document_url,


### PR DESCRIPTION
This adds handling of webmanifest links like:
```html
<link href=./manifest.webmanifest rel=manifest>
```

Context:
- [Web Manifests](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest)
- [The application/manifest+json MIME type](https://www.iana.org/assignments/media-types/application/manifest+json)

This PR fixes https://github.com/Y2Z/monolith/issues/475