### PR TITLE
Improve Dockerfile apk cache handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,7 @@ RUN make install
 
 FROM alpine
 
-RUN apk update && \
-  apk add --no-cache openssl && \
-  rm -rf "/var/cache/apk/*"
+RUN apk add --no-cache openssl
 
 COPY --from=builder /root/.cargo/bin/monolith /usr/bin/monolith
 WORKDIR /tmp


### PR DESCRIPTION
Drop the redundant apk update and cache removal commands in the runtime stage. The --no-cache flag already keeps the package index out of the layer, so the simplified instruction avoids needless work.

GitHub Copilot Summary:

> This pull request makes a minor change to the Dockerfile by simplifying the package installation step. The unnecessary cache clearing and update command have been removed, streamlining the build process.