### PR TITLE
fix: send all matching cookies instead of only the last one

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -1022,11 +1022,7 @@ pub fn walk(session: &mut Session, document_url: &Url, node: &Handle) {
                                 set_node_attr(node, attr_name, None);
                             } else if use_attr_href_value.clone().starts_with('#') {
                                 // Relative symbol that resolves to its own URL; keep as-is.
-                                set_node_attr(
-                                    node,
-                                    attr_name,
-                                    Some(use_attr_href_value),
-                                );
+                                set_node_attr(node, attr_name, Some(use_attr_href_value));
                             } else {
                                 let image_asset_url: Url =
                                     resolve_url(document_url, &use_attr_href_value);

--- a/src/session.rs
+++ b/src/session.rs
@@ -145,12 +145,17 @@ impl Session {
             // URL not in cache, we retrieve the file
             let mut headers = HeaderMap::new();
             if self.cookies.is_some() && !self.cookies.as_ref().unwrap().is_empty() {
+                let mut cookie_values: Vec<String> = Vec::new();
                 for cookie in self.cookies.as_ref().unwrap() {
                     if !cookie.is_expired() && cookie.matches_url(url.as_str()) {
-                        let cookie_header_value: String = cookie.name.clone() + "=" + &cookie.value;
-                        headers
-                            .insert(COOKIE, HeaderValue::from_str(&cookie_header_value).unwrap());
+                        cookie_values.push(cookie.name.clone() + "=" + &cookie.value);
                     }
+                }
+                if !cookie_values.is_empty() {
+                    headers.insert(
+                        COOKIE,
+                        HeaderValue::from_str(&cookie_values.join("; ")).unwrap(),
+                    );
                 }
             }
             // Add referer header for page resource requests


### PR DESCRIPTION
## What
Fixes a bug where only the last matching cookie was sent when multiple cookies matched a URL.

## Why
When using a cookies file with multiple cookies for the same domain, only one cookie would be sent in the HTTP request. This breaks websites that require multiple cookies for authentication or session management.

The root cause was using  inside a loop, which overwrote the Cookie header on each iteration.

## How
- Collect all matching cookie name=value pairs into a Vec
- Join them with  (per RFC 6265) 
- Insert the combined value as a single Cookie header

## Testing
- The fix follows RFC 6265 cookie formatting
- Verified the logic against the reproduction steps in #479
- Multiple cookies now correctly appear as 

Fixes #479