### PR TITLE
docs: note that -f also removes iframes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ cat some-site-page.html | monolith -aIiFfcMv -b https://some.site/ - > some-site
  - `-d`: Allow retrieving assets only from specified `domain(s)`
  - `-e`: Ignore network errors
  - `-E`: Save document using `custom encoding`
- - `-f`: Omit frames
+ - `-f`: Omit frames and iframes
  - `-F`: Exclude web fonts
  - `-h`: Print help information
  - `-i`: Remove images


### PR DESCRIPTION
The README's option list describes `-f` as **"Omit frames"**, but the flag's actual help text (`src/main.rs`) is **"Remove frames and iframes"** and it removes both `<frame>` and `<iframe>` elements.

This updates the README to **"Omit frames and iframes"** so it matches the flag's real behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)